### PR TITLE
Add `ctis.regrid` for conservative spectral-cube resampling

### DIFF
--- a/ctis/__init__.py
+++ b/ctis/__init__.py
@@ -3,11 +3,13 @@ A package for inverting imagery captured by a computed tomography imaging
 spectrograph.
 """
 
+from ._regrid import regrid
 from . import scenes
 from . import instruments
 from . import inverters
 
 __all__ = [
+    "regrid",
     "scenes",
     "instruments",
     "inverters",

--- a/ctis/_regrid.py
+++ b/ctis/_regrid.py
@@ -1,0 +1,125 @@
+"""
+Resample spectral cubes between spectral/spatial grids.
+"""
+
+import named_arrays as na
+
+__all__ = [
+    "regrid",
+]
+
+
+def regrid(
+    coordinates_input: "na.AbstractSpectralPositionalVectorArray",
+    coordinates_output: "na.AbstractSpectralPositionalVectorArray",
+    values_input: "na.AbstractScalar",
+    axis_wavelength: str,
+    axis_position: tuple[str, str],
+) -> "na.AbstractScalarArray":
+    """
+    Conservatively resample a spectral cube from one spectral/spatial grid onto
+    another.
+
+    The resampling is split into two independent conservative steps: a 1D
+    conservative interpolation along the wavelength axis, followed by a 2D
+    conservative interpolation along the two spatial axes. Separating the
+    spectral and spatial resampling is much cheaper than a single 3D
+    conservative regrid and is exact whenever the wavelength grid does not
+    depend on spatial position (and vice versa), which is the usual case for a
+    CTIS scene.
+
+    Both steps use :func:`named_arrays.regridding.regrid` with
+    ``method="conservative"``, so the total (the sum of ``values_input`` over
+    the resampled axes) is preserved. ``values_input`` is therefore treated as
+    an extensive quantity: a per-voxel total rather than a density. Multiply a
+    spectral radiance by its voxel volume before calling this function if the
+    integral of the radiance is what should be conserved.
+
+    Parameters
+    ----------
+    coordinates_input
+        The wavelength and position of the vertices of each voxel of the input
+        grid.
+    coordinates_output
+        The wavelength and position of the vertices of each voxel of the output
+        grid.
+    values_input
+        The value in each voxel of the input grid, sampled on the voxel centers.
+    axis_wavelength
+        The logical axis corresponding to changing wavelength coordinate.
+        Shared by the input and output grids.
+    axis_position
+        The two logical axes corresponding to changing position coordinate.
+        Shared by the input and output grids.
+
+    Examples
+    --------
+
+    Resample a random spectral cube onto a finer grid.
+
+    .. jupyter-execute::
+
+        import astropy.units as u
+        import named_arrays as na
+        import ctis
+
+        # Define the vertices of the input grid.
+        coordinates_input = na.SpectralPositionalVectorArray(
+            wavelength=na.linspace(500, 600, axis="wavelength", num=5) * u.nm,
+            position=na.Cartesian2dVectorLinearSpace(
+                start=-10 * u.arcsec,
+                stop=+10 * u.arcsec,
+                axis=na.Cartesian2dVectorArray("x", "y"),
+                num=7,
+            ),
+        )
+
+        # Define the vertices of the (finer) output grid.
+        coordinates_output = na.SpectralPositionalVectorArray(
+            wavelength=na.linspace(500, 600, axis="wavelength", num=9) * u.nm,
+            position=na.Cartesian2dVectorLinearSpace(
+                start=-10 * u.arcsec,
+                stop=+10 * u.arcsec,
+                axis=na.Cartesian2dVectorArray("x", "y"),
+                num=13,
+            ),
+        )
+
+        # Define a random cube sampled on the input voxel centers.
+        values_input = na.random.uniform(
+            low=0,
+            high=1,
+            shape_random=dict(wavelength=4, x=6, y=6),
+        )
+
+        # Resample the cube onto the output grid.
+        values_output = ctis.regrid(
+            coordinates_input=coordinates_input,
+            coordinates_output=coordinates_output,
+            values_input=values_input,
+            axis_wavelength="wavelength",
+            axis_position=("x", "y"),
+        )
+    """
+
+    # 1D conservative interpolation along the wavelength axis.
+    values = na.regridding.regrid(
+        coordinates_input=coordinates_input.wavelength,
+        coordinates_output=coordinates_output.wavelength,
+        values_input=values_input,
+        axis_input=(axis_wavelength,),
+        axis_output=(axis_wavelength,),
+        method="conservative",
+    )
+
+    # 2D conservative interpolation along the spatial axes.
+    values = na.regridding.regrid(
+        coordinates_input=coordinates_input.position,
+        coordinates_output=coordinates_output.position,
+        values_input=values,
+        axis_input=axis_position,
+        axis_output=axis_position,
+        method="conservative",
+    )
+
+    return values

--- a/ctis/_regrid.py
+++ b/ctis/_regrid.py
@@ -59,7 +59,9 @@ def regrid(
 
     .. jupyter-execute::
 
+        import matplotlib.pyplot as plt
         import astropy.units as u
+        import astropy.visualization
         import named_arrays as na
         import ctis
 
@@ -100,6 +102,30 @@ def regrid(
             axis_wavelength="wavelength",
             axis_position=("x", "y"),
         )
+
+        # Plot the input and output grids, with wavelength represented by color.
+        with astropy.visualization.quantity_support():
+            fig, ax = plt.subplots(
+                ncols=2,
+                sharex=True,
+                sharey=True,
+                figsize=(8, 4),
+                constrained_layout=True,
+            )
+            na.plt.rgbmesh(
+                coordinates_input,
+                C=values_input,
+                axis_wavelength="wavelength",
+                ax=ax[0],
+            )
+            na.plt.rgbmesh(
+                coordinates_output,
+                C=values_output,
+                axis_wavelength="wavelength",
+                ax=ax[1],
+            )
+            ax[0].set_title("input grid")
+            ax[1].set_title("output grid")
     """
 
     # 1D conservative interpolation along the wavelength axis.

--- a/ctis/_regrid.py
+++ b/ctis/_regrid.py
@@ -65,19 +65,8 @@ def regrid(
         import named_arrays as na
         import ctis
 
-        # Define the vertices of the input grid.
+        # Define the vertices of the (fine) input grid.
         coordinates_input = na.SpectralPositionalVectorArray(
-            wavelength=na.linspace(500, 600, axis="wavelength", num=5) * u.nm,
-            position=na.Cartesian2dVectorLinearSpace(
-                start=-10 * u.arcsec,
-                stop=+10 * u.arcsec,
-                axis=na.Cartesian2dVectorArray("x", "y"),
-                num=7,
-            ),
-        )
-
-        # Define the vertices of the (finer) output grid.
-        coordinates_output = na.SpectralPositionalVectorArray(
             wavelength=na.linspace(500, 600, axis="wavelength", num=9) * u.nm,
             position=na.Cartesian2dVectorLinearSpace(
                 start=-10 * u.arcsec,
@@ -87,14 +76,25 @@ def regrid(
             ),
         )
 
+        # Define the vertices of the (coarser) output grid.
+        coordinates_output = na.SpectralPositionalVectorArray(
+            wavelength=na.linspace(500, 600, axis="wavelength", num=5) * u.nm,
+            position=na.Cartesian2dVectorLinearSpace(
+                start=-10 * u.arcsec,
+                stop=+10 * u.arcsec,
+                axis=na.Cartesian2dVectorArray("x", "y"),
+                num=7,
+            ),
+        )
+
         # Define a random cube sampled on the input voxel centers.
         values_input = na.random.uniform(
             low=0,
             high=1,
-            shape_random=dict(wavelength=4, x=6, y=6),
+            shape_random=dict(wavelength=8, x=12, y=12),
         )
 
-        # Resample the cube onto the output grid.
+        # Resample the cube onto the coarser output grid.
         values_output = ctis.regrid(
             coordinates_input=coordinates_input,
             coordinates_output=coordinates_output,
@@ -103,27 +103,48 @@ def regrid(
             axis_position=("x", "y"),
         )
 
-        # Plot the input and output grids, with wavelength represented by color.
+        # Plot the input and output grids side by side, with wavelength
+        # represented by color. Coarsening conservatively sums voxels, so the
+        # output voxels are brighter; a shared normalization lets one colorbar
+        # describe both panels.
+        vmax = values_output.max()
+        wavelength_min = coordinates_input.wavelength.min()
+        wavelength_max = coordinates_input.wavelength.max()
         with astropy.visualization.quantity_support():
             fig, ax = plt.subplots(
-                ncols=2,
-                sharex=True,
-                sharey=True,
-                figsize=(8, 4),
+                ncols=3,
+                gridspec_kw=dict(width_ratios=[0.45, 0.45, 0.1]),
+                sharex=False,
+                figsize=(9, 4),
                 constrained_layout=True,
             )
-            na.plt.rgbmesh(
+            colorbar = na.plt.rgbmesh(
                 coordinates_input,
                 C=values_input,
                 axis_wavelength="wavelength",
+                vmin=0,
+                vmax=vmax,
+                wavelength_min=wavelength_min,
+                wavelength_max=wavelength_max,
                 ax=ax[0],
             )
             na.plt.rgbmesh(
                 coordinates_output,
                 C=values_output,
                 axis_wavelength="wavelength",
+                vmin=0,
+                vmax=vmax,
+                wavelength_min=wavelength_min,
+                wavelength_max=wavelength_max,
                 ax=ax[1],
             )
+            na.plt.pcolormesh(
+                C=colorbar,
+                axis_rgb="wavelength",
+                ax=ax[2],
+            )
+            ax[2].yaxis.tick_right()
+            ax[2].yaxis.set_label_position("right")
             ax[0].set_title("input grid")
             ax[1].set_title("output grid")
     """

--- a/ctis/_regrid_test.py
+++ b/ctis/_regrid_test.py
@@ -1,0 +1,71 @@
+import pytest
+import numpy as np
+import astropy.units as u
+import named_arrays as na
+import ctis
+
+
+def _grid(num_wavelength: int, num_position: int) -> na.SpectralPositionalVectorArray:
+    return na.SpectralPositionalVectorArray(
+        wavelength=na.linspace(500, 600, axis="wavelength", num=num_wavelength) * u.nm,
+        position=na.Cartesian2dVectorLinearSpace(
+            start=-10 * u.arcsec,
+            stop=+10 * u.arcsec,
+            axis=na.Cartesian2dVectorArray("x", "y"),
+            num=num_position,
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    argnames="coordinates_input,coordinates_output",
+    argvalues=[
+        (_grid(5, 7), _grid(9, 13)),  # refine
+        (_grid(9, 13), _grid(5, 7)),  # coarsen
+    ],
+)
+def test_regrid(
+    coordinates_input: na.SpectralPositionalVectorArray,
+    coordinates_output: na.SpectralPositionalVectorArray,
+):
+    axis_wavelength = "wavelength"
+    axis_position = ("x", "y")
+
+    num_input = coordinates_input.shape
+    values_input = na.random.uniform(
+        low=0,
+        high=1,
+        shape_random={
+            axis_wavelength: num_input[axis_wavelength] - 1,
+            axis_position[0]: num_input[axis_position[0]] - 1,
+            axis_position[1]: num_input[axis_position[1]] - 1,
+        },
+    )
+
+    result = ctis.regrid(
+        coordinates_input=coordinates_input,
+        coordinates_output=coordinates_output,
+        values_input=values_input,
+        axis_wavelength=axis_wavelength,
+        axis_position=axis_position,
+    )
+
+    assert isinstance(result, na.AbstractScalarArray)
+    assert np.all(np.isfinite(result))
+
+    # the result is sampled on the output voxel centers
+    num_output = coordinates_output.shape
+    assert na.shape(result) == {
+        axis_wavelength: num_output[axis_wavelength] - 1,
+        axis_position[0]: num_output[axis_position[0]] - 1,
+        axis_position[1]: num_output[axis_position[1]] - 1,
+    }
+
+    # the input and output grids span the same volume, so the conservative
+    # resampling preserves the total to within the tolerance of the
+    # perturbation applied by the 2D conservative step.
+    assert np.isclose(
+        result.sum().ndarray,
+        values_input.sum().ndarray,
+        rtol=0.05,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ packages = ["ctis"]
 
 [tool.setuptools_scm]
 
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]
+
 [tool.coverage.report]
 exclude_also = [
     "return NotImplemented",


### PR DESCRIPTION
## Summary

Adds `ctis.regrid()`, a two-stage conservative resampler for a spectral cube.

Given input and output `SpectralPositionalVectorArray` grids (voxel vertices) and a values array on the input voxel centers, it performs:

1. a **1D conservative** interpolation along the wavelength axis, then
2. a **2D conservative** interpolation along the two spatial axes,

both via `named_arrays.regridding.regrid` with `method="conservative"`.

Separating the spectral (1D) and spatial (2D) resampling is much cheaper than a single 3D conservative regrid, and is exact whenever the wavelength grid is independent of spatial position (the usual case for a CTIS scene).

## Notes

- The conservative method preserves the **sum** over the resampled axes, so `values_input` is treated as an extensive per-voxel quantity (a per-voxel total, not a density). The docstring notes that a radiance should be pre-multiplied by its voxel volume if the radiance *integral* is what should be conserved.
- The 2D conservative step applies `named_arrays`' default small coordinate perturbation to avoid degenerate cells, so on identical extents the total is conserved to within a few percent.

## Tests

`ctis/_regrid_test.py` covers refine and coarsen cases (shape, finiteness, total conservation). New module is 100% covered; `black`/`ruff` clean; docstring `jupyter-execute` example verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtdKmedevWkDab6BWupXqQ