### PR TITLE
Fix the convergence check being skipped when verbose=True

### DIFF
--- a/ctis/inverters/_iterative/_mart/_mart.py
+++ b/ctis/inverters/_iterative/_mart/_mart.py
@@ -131,7 +131,7 @@ class MartInverter(
             if verbose:  # pragma: nocover
                 print(f"merit: {merit}")
 
-            elif (merit_old - merit) < self.threshold_convergence:
+            if (merit_old - merit) < self.threshold_convergence:
                 message = f"Achieved merit less than {self.threshold_convergence}."
                 success = True
                 num_iteration = i + 1

--- a/ctis/inverters/_iterative/_mart/_mart_test.py
+++ b/ctis/inverters/_iterative/_mart/_mart_test.py
@@ -114,3 +114,19 @@ class TestMartInverter(
         assert isinstance(fig, plt.Figure)
         for ax in axs:
             assert isinstance(ax, plt.Axes)
+
+
+def test__call__verbose_convergence():
+    """
+    Verbose output must not disable the convergence check.
+    """
+    a = ctis.inverters.MartInverter(
+        instrument=instrument,
+        num_iteration=50,
+        threshold_convergence=1e-2,
+    )
+
+    result = a(images, verbose=True)
+
+    assert result.success
+    assert result.num_iteration < a.num_iteration


### PR DESCRIPTION
The convergence test in `MartInverter.__call__` was an `elif` chained behind the `verbose` print statement:

```python
if verbose:  # pragma: nocover
    print(f"merit: {merit}")

elif (merit_old - merit) < self.threshold_convergence:
    ...
    break
```

so any run with verbose output could never stop at the convergence threshold and always ran to `num_iteration` (with the max-iterations warning). Found while running MART inversions of the ESIS-I flight data, where verbose runs always burned the full iteration budget.

This splits the check into an independent `if`, and adds a regression test that inverts with `verbose=True` and asserts early convergence — the test fails on the previous code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HuYXL1BkWsWGAxYnpD8Kqz